### PR TITLE
Use user defined hover text for images in tasks

### DIFF
--- a/H5PEditor.DragQuestion.js
+++ b/H5PEditor.DragQuestion.js
@@ -973,6 +973,10 @@ H5PEditor.widgets.dragQuestion = H5PEditor.DragQuestion = (function ($, DragNBar
     if (type === 'text') {
       element.$element.addClass('h5p-dq-text');
     }
+    else if (type === 'image') {
+      // Override image hover and use user defined hover text or none
+      element.$innerElement.find('img').attr('title', params.type.params.title || '');
+    }
 
     // Find label text without html
     var label = (type === 'text' ? $('<div>' + params.type.params.text + '</div>').text() : params.type.params.alt + '');


### PR DESCRIPTION
With changing the image hover handling when metadata were introduced, static images and draggable images used the image's metadata title for the hover text, but not what the user specified in the editor of Drag-and-Drop.

This change overrides the image hover text for static images and draggable images. It will be set to what's specified by the user, so possibly empty and not displayed at all.

There's a similar pull request for the view of Drag-and-Drop.