### PR TITLE
HFP-1884 Set text content centered by default

### DIFF
--- a/H5PEditor.DragQuestion.js
+++ b/H5PEditor.DragQuestion.js
@@ -610,6 +610,16 @@ H5PEditor.widgets.dragQuestion = H5PEditor.DragQuestion = (function ($, DragNBar
   C.prototype.insertElement = function (index) {
     var that = this;
     var elementParams = this.params.elements[index];
+
+    // Ensure that newly created elements have a text field with centered text
+    if (elementParams.type?.library.startsWith('H5P.AdvancedText ')) {
+      elementParams.type.params === elementParams.type.params ?? {};
+      if (typeof elementParams.type.params.text !== 'string') {
+        elementParams.type.params.text =
+          '<p style="text-align: center;"></p>';
+      }
+    }
+
     var element = this.generateForm(this.elementFields, elementParams);
 
     var library = this.children[0];


### PR DESCRIPTION
When merged in, will center the text in the respective CKEditor field for text draggables because that is the default behavior.

Accompanies HFP-1884 pull request for H5P.DragQuestion but does not hurt on its own either: https://github.com/h5p/h5p-drag-question/pull/168